### PR TITLE
Added separate check to ensure the wp_locale property exists

### DIFF
--- a/i18n-module.php
+++ b/i18n-module.php
@@ -250,6 +250,10 @@ class yoast_i18n {
 		if ( $body ) {
 			$body = json_decode( $body );
 			foreach ( $body->translation_sets as $set ) {
+				if ( ! property_exists( $set, 'wp_locale' ) ) {
+					continue;
+				}
+
 				if ( $this->locale == $set->wp_locale ) {
 					return $set;
 				}


### PR DESCRIPTION
This resolves the issue that a warning message is shown if the API call doesn't have the `wp_locale` property for a particular translation set.