### PR TITLE
6877 change translate box to notification

### DIFF
--- a/src/i18n-module-wordpressorg.php
+++ b/src/i18n-module-wordpressorg.php
@@ -26,7 +26,7 @@ class Yoast_I18n_WordPressOrg_v2 {
 	}
 
 	/**
-	 * Returns the i18n_promo message from the i18n_module if the i18n promo should be shown.
+	 * Returns the i18n_promo message from the i18n_module. Returns en empty string if the promo shouldn't be shown.
 	 *
 	 * @access public
 	 *

--- a/src/i18n-module-wordpressorg.php
+++ b/src/i18n-module-wordpressorg.php
@@ -30,17 +30,8 @@ class Yoast_I18n_WordPressOrg_v2 {
 	 *
 	 * @return string The i18n promo message.
 	 */
-	public function promo_message() {
-		return $this->i18n->promo_message();
-	}
-
-	/**
-	 * Returns whether admin is loaded and the language is not en_US.
-	 *
-	 * @return bool If admin is loaded and the language is not en_US.
-	 */
-	public function is_admin_in_other_language() {
-		return $this->i18n->is_admin_in_other_language();
+	public function get_promo_message() {
+		return $this->i18n->get_promo_message();
 	}
 
 	/**

--- a/src/i18n-module-wordpressorg.php
+++ b/src/i18n-module-wordpressorg.php
@@ -26,13 +26,25 @@ class Yoast_I18n_WordPressOrg_v2 {
 	}
 
 	/**
-	 * Returns the i18n_promo message from the i18n_module. Returns en empty string if the
-	 * promo shouldn't be shown.
+	 * Returns the i18n_promo message from the i18n_module if the i18n promo should be shown.
+	 *
+	 * @access public
 	 *
 	 * @return string The i18n promo message.
 	 */
 	public function get_promo_message() {
 		return $this->i18n->get_promo_message();
+	}
+
+	/**
+	 * Returns a button that can be used to dismiss the i18n-message.
+	 *
+	 * @access private
+	 *
+	 * @return string
+	 */
+	public function get_dismiss_i18n_message_button() {
+		return $this->i18n->get_dismiss_i18n_message_button();
 	}
 
 	/**

--- a/src/i18n-module-wordpressorg.php
+++ b/src/i18n-module-wordpressorg.php
@@ -26,7 +26,8 @@ class Yoast_I18n_WordPressOrg_v2 {
 	}
 
 	/**
-	 * Returns the i18n_promo message from the i18n_module.
+	 * Returns the i18n_promo message from the i18n_module. Returns en empty string if the
+	 * promo shouldn't be shown.
 	 *
 	 * @return string The i18n promo message.
 	 */

--- a/src/i18n-module-wordpressorg.php
+++ b/src/i18n-module-wordpressorg.php
@@ -15,13 +15,32 @@ class Yoast_I18n_WordPressOrg_v2 {
 	/**
 	 * Constructs the i18n module for wordpress.org. Required fields are the 'textdomain', 'plugin_name' and 'hook'
 	 *
-	 * @param array $args The settings for the i18n module.
+	 * @param array $args                   The settings for the i18n module.
+	 * @param bool $show_translation_box    Whether the translation box should be shown.
 	 */
-	public function __construct( $args ) {
+	public function __construct( $args, $show_translation_box = true ) {
 		$args = $this->set_defaults( $args );
 
-		$this->i18n = new Yoast_I18n_v2( $args );
+		$this->i18n = new Yoast_I18n_v2( $args, $show_translation_box );
 		$this->set_api_url( $args['textdomain'] );
+	}
+
+	/**
+	 * Returns the i18n_promo message from the i18n_module.
+	 *
+	 * @return string The i18n promo message.
+	 */
+	public function promo_message() {
+		return $this->i18n->promo_message();
+	}
+
+	/**
+	 * Returns whether admin is loaded and the language is not en_US.
+	 *
+	 * @return bool If admin is loaded and the language is not en_US.
+	 */
+	public function is_admin_in_other_language() {
+		return $this->i18n->is_admin_in_other_language();
 	}
 
 	/**

--- a/src/i18n-module.php
+++ b/src/i18n-module.php
@@ -130,9 +130,9 @@ class Yoast_I18n_v2 {
 	}
 
 	/**
-	 * Returns whether admin is loaded and the language is not en_US.
+	 * Returns whether the language is en_US.
 	 *
-	 * @return bool If admin is loaded and the language is not en_US.
+	 * @return bool Returns true if the language is en_US.
 	 */
 	protected function is_default_language() {
 		return 'en_US' === $this->locale;

--- a/src/i18n-module.php
+++ b/src/i18n-module.php
@@ -206,11 +206,9 @@ class Yoast_I18n_v2 {
 			$notification_center->add_notification( $notification );
 
 			if ( 'en_US' !== $this->locale ) {
-				printf("<script>console.log('%s');</script>", 'Voeg de notificatie toe' );
 				$notification_center->add_notification( $notification );
 			}
 			else {
-				printf("<script>console.log('%s');</script>", 'Haal de notificatie weg' );
 				$notification_center->remove_notification( $notification );
 			}
 		}

--- a/src/i18n-module.php
+++ b/src/i18n-module.php
@@ -121,12 +121,13 @@ class Yoast_I18n_v2 {
 
 		$this->locale = $this->get_admin_locale();
 
-		if( $this->is_default_language( $this->locale ) ) {
+		if ( $this->is_default_language( $this->locale ) ) {
 			return;
 
 		}
 
 		$this->init( $args );
+
 		if ( $show_translation_box && ! $this->hide_promo() ) {
 			add_action( $this->hook, array( $this, 'promo' ) );
 		}
@@ -135,7 +136,7 @@ class Yoast_I18n_v2 {
 	/**
 	 * Returns whether the language is en_US.
 	 *
-	 * @param string $language The language to
+	 * @param string $language The language to check.
 	 *
 	 * @return bool Returns true if the language is en_US.
 	 */

--- a/src/i18n-module.php
+++ b/src/i18n-module.php
@@ -115,9 +115,13 @@ class Yoast_I18n_v2 {
 	 * @param bool $show_translation_box    Whether the translation box should be shown.
 	 */
 	public function __construct( $args, $show_translation_box = true ) {
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		$this->locale = $this->get_admin_locale();
 
-		if( $this->is_admin_in_other_language() ) {
+		if( ! $this->is_default_language() ) {
 			$this->init( $args );
 			if ( $show_translation_box && ! $this->hide_promo() ) {
 				add_action( $this->hook, array( $this, 'promo' ) );
@@ -130,8 +134,8 @@ class Yoast_I18n_v2 {
 	 *
 	 * @return bool If admin is loaded and the language is not en_US.
 	 */
-	public function is_admin_in_other_language() {
-		return is_admin() && 'en_US' !== $this->locale;
+	protected function is_default_language() {
+		return 'en_US' === $this->locale;
 	}
 
 	/**
@@ -191,7 +195,7 @@ class Yoast_I18n_v2 {
 	 * @return string The i18n promo message.
 	 */
 	public function get_promo_message() {
-		if ( $this->is_admin_in_other_language() ) {
+		if ( ! $this->is_default_language() ) {
 			return $this->promo_message();
 		}
 

--- a/src/i18n-module.php
+++ b/src/i18n-module.php
@@ -119,9 +119,15 @@ class Yoast_I18n_v2 {
 		}
 
 		$this->locale = $this->get_admin_locale();
+		if ( 'en_US' === $this->locale ) {
+			return;
+		}
+
 		$this->init( $args );
 
-		add_action( $this->hook, array( $this, 'promo' ) );
+		if ( ! $this->hide_promo() ) {
+			add_action( $this->hook, array( $this, 'promo' ) );
+		}
 	}
 
 	/**
@@ -157,6 +163,26 @@ class Yoast_I18n_v2 {
 	}
 
 	/**
+	 * Check whether the promo should be hidden or not
+	 *
+	 * @access private
+	 *
+	 * @return bool
+	 */
+	private function hide_promo() {
+		$hide_promo = get_transient( 'yoast_i18n_' . $this->project_slug . '_promo_hide' );
+		if ( ! $hide_promo ) {
+			if ( filter_input( INPUT_GET, 'remove_i18n_promo', FILTER_VALIDATE_INT ) === 1 ) {
+				// No expiration time, so this would normally not expire, but it wouldn't be copied to other sites etc.
+				set_transient( 'yoast_i18n_' . $this->project_slug . '_promo_hide', true );
+				$hide_promo = true;
+			}
+		}
+
+		return $hide_promo;
+	}
+
+	/**
 	 * Generates a promo message
 	 *
 	 * @access private
@@ -189,28 +215,18 @@ class Yoast_I18n_v2 {
 		$message = $this->promo_message();
 
 		if ( $message ) {
-			if ( ! class_exists( 'Yoast_Notification_Center' ) ) {
-				return;
+			echo '<div id="i18n_promo_box" style="border:1px solid #ccc;background-color:#fff;padding:10px;max-width:650px; overflow: hidden;">';
+			echo '<a href="' . esc_url( add_query_arg( array( 'remove_i18n_promo' => '1' ) ) ) . '" style="color:#333;text-decoration:none;font-weight:bold;font-size:16px;border:1px solid #ccc;padding:1px 4px;" class="alignright">X</a>';
+
+			echo '<div>';
+			echo '<h2>' . sprintf( __( 'Translation of %s', $this->textdomain ), $this->plugin_name ) . '</h2>';
+			if ( isset( $this->glotpress_logo ) && '' != $this->glotpress_logo ) {
+				echo '<a href="' . esc_url( $this->register_url ) . '"><img class="alignright" style="margin:0 5px 5px 5px;max-width:200px;" src="' . esc_url( $this->glotpress_logo ) . '" alt="' . esc_attr( $this->glotpress_name ) . '"/></a>';
 			}
-
-			$notification_center = Yoast_Notification_Center::get();
-
-			$notification        = new Yoast_Notification(
-				$this->promo_message() . '<p><a href="' . esc_url( $this->register_url ) . '">' . __( 'Register now &raquo;', $this->textdomain ) . '</a></p>',
-				array(
-					'type' => Yoast_Notification::WARNING,
-					'id'   => 'i18nModuleTranslationAssistance',
-				)
-			);
-
-			$notification_center->add_notification( $notification );
-
-			if ( 'en_US' !== $this->locale ) {
-				$notification_center->add_notification( $notification );
-			}
-			else {
-				$notification_center->remove_notification( $notification );
-			}
+			echo '<p>' . $message . '</p>';
+			echo '<p><a href="' . esc_url( $this->register_url ) . '">' . __( 'Register now &raquo;', $this->textdomain ) . '</a></p>';
+			echo '</div>';
+			echo '</div>';
 		}
 	}
 

--- a/src/i18n-module.php
+++ b/src/i18n-module.php
@@ -123,12 +123,11 @@ class Yoast_I18n_v2 {
 
 		if ( $this->is_default_language( $this->locale ) ) {
 			return;
-
 		}
 
 		$this->init( $args );
 
-		if ( $show_translation_box && ! $this->hide_promo() ) {
+		if ( $show_translation_box ) {
 			add_action( $this->hook, array( $this, 'promo' ) );
 		}
 	}
@@ -203,7 +202,7 @@ class Yoast_I18n_v2 {
 	 * @return string The i18n promo message.
 	 */
 	public function get_promo_message() {
-		if ( ! $this->is_default_language( $this->locale ) ) {
+		if ( ( ! $this->is_default_language( $this->locale )  ) && ( ! $this->hide_promo() ) ) {
 			return $this->promo_message();
 		}
 
@@ -239,6 +238,22 @@ class Yoast_I18n_v2 {
 		}
 
 		return $message;
+	}
+
+	/**
+	 * Returns a button that can be used to dismiss the i18n-message.
+	 *
+	 * @access private
+	 *
+	 * @return string
+	 */
+	public function get_dismiss_i18n_message_button() {
+		return sprintf(
+		/* translators: %1$s is the notification dismissal link start tag, %2$s is the link closing tag. */
+			__( '%1$sPlease don\'t show me this notification anymore%2$s', $this->textdomain ),
+			'<a class="button" href="' . esc_url( add_query_arg( array( 'remove_i18n_promo' => '1' ) ) ) . '">',
+			'</a>'
+		);
 	}
 
 	/**

--- a/src/i18n-module.php
+++ b/src/i18n-module.php
@@ -121,21 +121,26 @@ class Yoast_I18n_v2 {
 
 		$this->locale = $this->get_admin_locale();
 
-		if( ! $this->is_default_language() ) {
-			$this->init( $args );
-			if ( $show_translation_box && ! $this->hide_promo() ) {
-				add_action( $this->hook, array( $this, 'promo' ) );
-			}
+		if( $this->is_default_language( $this->locale ) ) {
+			return;
+
+		}
+
+		$this->init( $args );
+		if ( $show_translation_box && ! $this->hide_promo() ) {
+			add_action( $this->hook, array( $this, 'promo' ) );
 		}
 	}
 
 	/**
 	 * Returns whether the language is en_US.
 	 *
+	 * @param string $language The language to
+	 *
 	 * @return bool Returns true if the language is en_US.
 	 */
-	protected function is_default_language() {
-		return 'en_US' === $this->locale;
+	protected function is_default_language( $language  ) {
+		return 'en_US' === $language;
 	}
 
 	/**
@@ -192,22 +197,22 @@ class Yoast_I18n_v2 {
 	/**
 	 * Returns the i18n_promo message from the i18n_module if the i18n promo should be shown.
 	 *
+	 * @access public
+	 *
 	 * @return string The i18n promo message.
 	 */
 	public function get_promo_message() {
-		if ( ! $this->is_default_language() ) {
+		if ( ! $this->is_default_language( $this->locale ) ) {
 			return $this->promo_message();
 		}
 
 		return '';
 	}
 
-
-
 	/**
 	 * Generates a promo message
 	 *
-	 * @access public
+	 * @access private
 	 *
 	 * @return bool|string $message
 	 */
@@ -228,7 +233,7 @@ class Yoast_I18n_v2 {
 		$registration_link = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $this->register_url ), esc_html( $this->glotpress_name ) );
 		$message           = sprintf( $message, esc_html( $this->locale_name ), esc_html( $this->plugin_name ), $this->percent_translated, $registration_link );
 
-		if( $message ) {
+		if ( $message ) {
 			$message = '<p>' . $message . '</p>' . '<p><a href="' . esc_url( $this->register_url ) . '">' . __( 'Register now &raquo;', $this->textdomain ) . '</a></p>';
 		}
 

--- a/src/i18n-module.php
+++ b/src/i18n-module.php
@@ -115,10 +115,11 @@ class Yoast_I18n_v2 {
 	 * @param bool $show_translation_box    Whether the translation box should be shown.
 	 */
 	public function __construct( $args, $show_translation_box = true ) {
+		$this->locale = $this->get_admin_locale();
+
 		if( $this->is_admin_in_other_language() ) {
 			$this->init( $args );
-
-			if ( $show_translation_box ) {
+			if ( $show_translation_box && ! $this->hide_promo() ) {
 				add_action( $this->hook, array( $this, 'promo' ) );
 			}
 		}
@@ -130,7 +131,6 @@ class Yoast_I18n_v2 {
 	 * @return bool If admin is loaded and the language is not en_US.
 	 */
 	public function is_admin_in_other_language() {
-		$this->locale = $this->get_admin_locale();
 		return is_admin() && 'en_US' !== $this->locale;
 	}
 
@@ -166,6 +166,39 @@ class Yoast_I18n_v2 {
 		}
 	}
 
+	/**
+	 * Check whether the promo should be hidden or not
+	 *
+	 * @access private
+	 *
+	 * @return bool
+	 */
+	private function hide_promo() {
+		$hide_promo = get_transient( 'yoast_i18n_' . $this->project_slug . '_promo_hide' );
+		if ( ! $hide_promo ) {
+			if ( filter_input( INPUT_GET, 'remove_i18n_promo', FILTER_VALIDATE_INT ) === 1 ) {
+				// No expiration time, so this would normally not expire, but it wouldn't be copied to other sites etc.
+				set_transient( 'yoast_i18n_' . $this->project_slug . '_promo_hide', true );
+				$hide_promo = true;
+			}
+		}
+		return $hide_promo;
+	}
+
+	/**
+	 * Returns the i18n_promo message from the i18n_module if the i18n promo should be shown.
+	 *
+	 * @return string The i18n promo message.
+	 */
+	public function get_promo_message() {
+		if ( $this->is_admin_in_other_language() ) {
+			return $this->promo_message();
+		}
+
+		return '';
+	}
+
+
 
 	/**
 	 * Generates a promo message
@@ -174,7 +207,7 @@ class Yoast_I18n_v2 {
 	 *
 	 * @return bool|string $message
 	 */
-	public function promo_message() {
+	private function promo_message() {
 
 		$this->translation_details();
 
@@ -204,7 +237,7 @@ class Yoast_I18n_v2 {
 	 * @access public
 	 */
 	public function promo() {
-		$message = $this->promo_message();
+		$message = $this->get_promo_message();
 
 		if ( $message ) {
 			echo '<div id="i18n_promo_box" style="border:1px solid #ccc;background-color:#fff;padding:10px;max-width:650px; overflow: hidden;">';

--- a/src/i18n-module.php
+++ b/src/i18n-module.php
@@ -195,14 +195,14 @@ class Yoast_I18n_v2 {
 	}
 
 	/**
-	 * Returns the i18n_promo message from the i18n_module if the i18n promo should be shown.
+	 * Returns the i18n_promo message from the i18n_module. Returns en empty string if the promo shouldn't be shown.
 	 *
 	 * @access public
 	 *
 	 * @return string The i18n promo message.
 	 */
 	public function get_promo_message() {
-		if ( ( ! $this->is_default_language( $this->locale )  ) && ( ! $this->hide_promo() ) ) {
+		if ( ! $this->is_default_language( $this->locale ) && ! $this->hide_promo() ) {
 			return $this->promo_message();
 		}
 
@@ -249,7 +249,7 @@ class Yoast_I18n_v2 {
 	 */
 	public function get_dismiss_i18n_message_button() {
 		return sprintf(
-		/* translators: %1$s is the notification dismissal link start tag, %2$s is the link closing tag. */
+			/* translators: %1$s is the notification dismissal link start tag, %2$s is the link closing tag. */
 			__( '%1$sPlease don\'t show me this notification anymore%2$s', $this->textdomain ),
 			'<a class="button" href="' . esc_url( add_query_arg( array( 'remove_i18n_promo' => '1' ) ) ) . '">',
 			'</a>'


### PR DESCRIPTION
#Changed translate promo box to a notification. 


The notification doesn't look all that spectacular right now. I removed the image for now as I couldn't duplicate the previous style exactly as the glotpress-logo can't go further right in the notification window. (check out the third screenshot to see what I mean).

***Previous promobox:***
<img width="537" alt="dfssdf" src="https://user-images.githubusercontent.com/11849359/28669314-17577ba4-72d4-11e7-863d-d07a754d0c0b.png">

***As a notification:***
<img width="855" alt="general_-_yoast_seo_ _local_wordpress_dev_ _wordpress" src="https://user-images.githubusercontent.com/11849359/28669303-0da045dc-72d4-11e7-820c-dfce9a2b000f.png">

***As a notification with the image:***
<img width="793" alt="general_-_yoast_seo_ _local_wordpress_dev_ _wordpress" src="https://user-images.githubusercontent.com/11849359/28706867-6bcdf468-7376-11e7-9246-a07c895fc9bd.png">

For now I kept the text-only version. We probably want to add the image somehow, and I've asked for a styling suggestion that can be implemented in a different issue.

Test instructions. Using this branch. 
- Make sure https://github.com/Yoast/wordpress-seo/pull/7608 is checked out as well. 
- delete from wp_options the entry with option name _transient_yoast_i18n_wordpress-seo_promo_hide, if it exists. ```DELETE FROM `wp_options` WHERE `option_name` = '_transient_yoast_i18n_wordpress-seo_promo_hide'```
- Have locale set as En_Us, check whether neither the previous promotion box nor the new notification is showing. 
- Have locale set as something else then En_Us, check whether the previous promotion box is not showing and the new notification is showing. 
- use the "please don't show me this notification anymore" and check whether the notification is removed entirely from the notification center

After discussion. It's been decided the notification should have a "don't show me this message again" link. Which should remove it from the notification center entirely without showing it again.

When switching languages, The notification should of course change to reflect the different language, but no changes to the notification status (show| dismissed| permanently dismissed) need to be made.

fixes https://github.com/Yoast/wordpress-seo/issues/6877
