### PR TITLE
Update `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-vendor
+vendor/
+composer.lock
+.idea/
+.phpcs.xml
+phpcs.xml


### PR DESCRIPTION
Ignore:
* Typical PHPStorm/IDE directory.
* The `vendor` directory and the `composer.lock` file. This is a library, not a stand-alone application and therefore the `composer.lock` file should not be committed.
* Ignore potential user PHPCS rulesets.