### PR TITLE
CS/QA: replace a loose comparison

### DIFF
--- a/src/i18n-module.php
+++ b/src/i18n-module.php
@@ -270,7 +270,7 @@ class Yoast_I18n_v3 {
 
 			echo '<div>';
 			echo '<h2>' . sprintf( __( 'Translation of %s', $this->textdomain ), $this->plugin_name ) . '</h2>';
-			if ( isset( $this->glotpress_logo ) && '' != $this->glotpress_logo ) {
+			if ( isset( $this->glotpress_logo ) && is_string( $this->glotpress_logo ) && '' !== $this->glotpress_logo ) {
 				echo '<a href="' . esc_url( $this->register_url ) . '"><img class="alignright" style="margin:0 5px 5px 5px;max-width:200px;" src="' . esc_url( $this->glotpress_logo ) . '" alt="' . esc_attr( $this->glotpress_name ) . '"/></a>';
 			}
 			echo $message;


### PR DESCRIPTION
Reasoning:
* Initially the property is `null` (not set).
* The property may get initialized by it being passed in via `$args`. In that case, it is expected to be a `string`, but there is no type check anywhere, so it could be something else.

Having said that, changing this to a strict comparison could still create a passing condition, unless we also add an `is_string()` as well.