### PR TITLE
I18n/bugfix: escape literal percentage signs

### DIFF
--- a/src/i18n-module.php
+++ b/src/i18n-module.php
@@ -223,9 +223,9 @@ class Yoast_I18n_v3 {
 		$message = false;
 
 		if ( $this->translation_exists && $this->translation_loaded && $this->percent_translated < 90 ) {
-			$message = __( 'As you can see, there is a translation of this plugin in %1$s. This translation is currently %3$d%% complete. We need your help to make it complete and to fix any errors. Please register at %4$s to help complete the translation to %1$s!', $this->textdomain );
+			$message = __( 'As you can see, there is a translation of this plugin in %1$s. This translation is currently %3$d%%% complete. We need your help to make it complete and to fix any errors. Please register at %4$s to help complete the translation to %1$s!', $this->textdomain );
 		} else if ( ! $this->translation_loaded && $this->translation_exists ) {
-			$message = __( 'You\'re using WordPress in %1$s. While %2$s has been translated to %1$s for %3$d%%, it\'s not been shipped with the plugin yet. You can help! Register at %4$s to help complete the translation to %1$s!', $this->textdomain );
+			$message = __( 'You\'re using WordPress in %1$s. While %2$s has been translated to %1$s for %3$d%%%, it\'s not been shipped with the plugin yet. You can help! Register at %4$s to help complete the translation to %1$s!', $this->textdomain );
 		} else if ( ! $this->translation_exists ) {
 			$message = __( 'You\'re using WordPress in a language we don\'t support yet. We\'d love for %2$s to be translated in that language too, but unfortunately, it isn\'t right now. You can change that! Register at %4$s to help translate it!', $this->textdomain );
 		}


### PR DESCRIPTION
The phrases passed to these `__()` functions are used a few lines down in a `sprintf()` to do the variable replacements. To use a literal `%` in a string passed to `sprintf()`, you need to escape it with an additional `%`.

Ref: http://php.net/manual/en/function.sprintf.php