### PR TITLE
CS: fix capitalization in class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Alternatively you can include the library as a submodule.
 Make sure the class is loaded and instantiate it like this:
 
 ```php
-new Yoast_I18n_v3(
+new Yoast_I18n_V3(
 	array(
 		'textdomain'     => '{your text domain}',
 		'project_slug'   => '{your probject slug}',
@@ -38,7 +38,7 @@ new Yoast_I18n_v3(
 Because translate.wordpress.org is also a GlotPress installation you can use the i18n-module to promote translation your plugin on there. To do this you can use the dedicated wordpress.org class:
 
 ```php
-new Yoast_I18n_WordPressOrg_v3(
+new Yoast_I18n_WordPressOrg_V3(
 	array(
 		'textdomain'  => '{your text domain}',
 		'plugin_name' => '{your plugin name}',
@@ -52,7 +52,7 @@ new Yoast_I18n_WordPressOrg_v3(
 Since 3.0.0 you can also decide to render the message in a message-box of your own, just provide the second argument to the constructor as `false` to disable the showing of the box by the module itself.
 
 ```php
-$i18n_module = new Yoast_I18n_v3(
+$i18n_module = new Yoast_I18n_V3(
 	array(
 		'textdomain'     => '{your text domain}',
 		'project_slug'   => '{your probject slug}',
@@ -70,7 +70,7 @@ $message = $i18n_module->get_promo_message();
 ```
 
 ```php
-$i18n_module = new Yoast_I18n_WordPressOrg_v3(
+$i18n_module = new Yoast_I18n_WordPressOrg_V3(
 	array(
 		'textdomain'  => '{your text domain}',
 		'plugin_name' => '{your plugin name}',

--- a/src/i18n-module-wordpressorg.php
+++ b/src/i18n-module-wordpressorg.php
@@ -3,12 +3,12 @@
 /**
  * The Yoast i18n module with a connection to WordPress.org.
  */
-class Yoast_I18n_WordPressOrg_v3 {
+class Yoast_I18n_WordPressOrg_V3 {
 
 	/**
 	 * The i18n object that presents the user with the notification.
 	 *
-	 * @var yoast_i18n_v3
+	 * @var yoast_i18n_V3
 	 */
 	protected $i18n;
 
@@ -21,7 +21,7 @@ class Yoast_I18n_WordPressOrg_v3 {
 	public function __construct( $args, $show_translation_box = true ) {
 		$args = $this->set_defaults( $args );
 
-		$this->i18n = new Yoast_I18n_v3( $args, $show_translation_box );
+		$this->i18n = new Yoast_I18n_V3( $args, $show_translation_box );
 		$this->set_api_url( $args['textdomain'] );
 	}
 

--- a/src/i18n-module.php
+++ b/src/i18n-module.php
@@ -3,7 +3,7 @@
 /**
  * This class defines a promo box and checks your translation site's API for stats about it, then shows them to the user.
  */
-class Yoast_I18n_v3 {
+class Yoast_I18n_V3 {
 
 	/**
 	 * Your translation site's logo


### PR DESCRIPTION
This is a safe change. Class names in PHP are case-insensitive, so changing the capitalization of the class names will not break any integrations, while it ensures compliance with the `Camel_Caps` class name rule.