### PR TITLE
Security: add Roave/SecurityAdvisories dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,8 @@
     },
     "autoload"   : {
         "classmap": ["src/"]
+    },
+    "require-dev": {
+        "roave/security-advisories": "dev-master"
     }
 }


### PR DESCRIPTION
This dependency will prevent packages with known security issues from being installed through Composer.

The package will always have to be at `dev-master` to make sure that the latest security information available will be used.

Refs:
* https://github.com/Roave/SecurityAdvisories
* https://www.bleepingcomputer.com/news/security/php-community-takes-steps-to-stop-installation-of-libraries-with-unpatched-bugs/
* https://websec.io/2018/03/10/Package-Protection-Roave-SecurityAdvisories.html