### PR TITLE
CS: add PHPCS ruleset and check via Travis

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<ruleset name="Yoast I18n module">
+	<description>Yoast I18n module rules for PHP_CodeSniffer</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	#############################################################################
+	-->
+
+	<file>.</file>
+
+	<exclude-pattern>vendor/*</exclude-pattern>
+
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Show progress, show the error codes for each message (source). -->
+	<arg value="ps"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultanously. -->
+	<arg name="parallel" value="8"/>
+
+
+	<!--
+	#############################################################################
+	USE THE YoastCS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="Yoast">
+		<!-- Can't be helped, textdomain is passed in dynamically, that's the nature of this module. -->
+		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralDomain"/>
+	</rule>
+
+
+	<!--
+	#############################################################################
+	SNIFF SPECIFIC CONFIGURATION
+	#############################################################################
+	-->
+
+	<!-- Set the minimum supported WP version. This is used by several sniffs. -->
+	<config name="minimum_supported_wp_version" value="4.8"/>
+
+	<rule ref="Yoast.Files.FileName">
+		<properties>
+			<!-- Remove the following prefixes from the names of object structures. -->
+			<property name="prefixes" type="array" value="yoast"/>
+		</properties>
+	</rule>
+
+	<!-- Verify that everything in the global namespace is prefixed with a plugin specific prefix. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<!-- Provide the prefixes to look for. -->
+			<property name="prefixes" type="array" value="yoast"/>
+		</properties>
+	</rule>
+
+
+	<!--
+	#############################################################################
+	SELECTIVE EXCLUSIONS
+	Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
+	#############################################################################
+	-->
+
+	<rule ref="WordPress.VIP.RestrictedFunctions">
+		<!-- This should be fine as long as the module is not used on the VIP platform.
+			 If/when it will be a wrapper can be used to use the VIP method when available
+			 and the WP native method when not.
+		-->
+		<properties>
+			<property name="exclude" value="wp_remote_get"/>
+		</properties>
+	</rule>
+
+</ruleset>

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
   fast_finish: true
   include:
     - php: 7.2
+      env: PHPCS=1
     - php: 5.3
       dist: precise
     - php: 5.2
@@ -34,6 +35,12 @@ jobs:
     # Allow failures for unstable builds.
     - php: nightly
 
+before_install:
+  - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+
+install:
+  - if [[ $PHPCS == "1" ]]; then composer install --prefer-dist --no-interaction; fi
+
 script:
 # PHP Linting
 - if find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi
@@ -41,3 +48,6 @@ script:
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate
 - if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.2" ]]; then composer validate --no-check-all; fi
+
+# Check the code against YoastCS.
+- if [[ $PHPCS == "1" ]]; then vendor/bin/phpcs -q; fi

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/Yoast/i18n-module.png?branch=master)](https://travis-ci.org/Yoast/i18n-module)
 [![Code Climate](https://codeclimate.com/github/Yoast/i18n-module/badges/gpa.svg)](https://codeclimate.com/github/Yoast/i18n-module)
 
 # Yoast i18n module

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,8 @@
         "classmap": ["src/"]
     },
     "require-dev": {
-        "roave/security-advisories": "dev-master"
+        "roave/security-advisories": "dev-master",
+        "yoast/yoastcs": "~0.5.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
     }
 }


### PR DESCRIPTION
This PR:
* Adds Yoast to the composer `--dev` dependencies
* Add the Dealerdirect PHPCS Composer plugin to the composer `--dev` dependencies to sort out the registration of the rulesets with PHPCS
* Adds a simple PHPCS ruleset based on the YoastCS ruleset
* Adds checking against this ruleset to the Travis script for PHP 7.2.
    No need to add it to more builds as all sniffs are unit tested against all supported PHP versions to give the same results.
* Adds a Travis "build status" badge to the readme.