### PR TITLE
CS: Update PHPCS ruleset for PHPCS 3.3.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -50,7 +50,9 @@
 	<rule ref="Yoast.Files.FileName">
 		<properties>
 			<!-- Remove the following prefixes from the names of object structures. -->
-			<property name="prefixes" type="array" value="yoast"/>
+			<property name="prefixes" type="array">
+				<element value="yoast"/>
+			</property>
 		</properties>
 	</rule>
 
@@ -58,7 +60,9 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Provide the prefixes to look for. -->
-			<property name="prefixes" type="array" value="yoast"/>
+			<property name="prefixes" type="array">
+				<element value="yoast"/>
+			</property>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
Use the new property array format. The old format is still supported for now, but will be removed in PHPCS 4.0.

See: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.3.0

As this repo does not have a `composer.lock` file, no other changes are needed AFAICS.