### PR TITLE
PHPCS: Update to use YoastCS 1.0 / WPCS 1.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -66,22 +66,4 @@
 		</properties>
 	</rule>
 
-
-	<!--
-	#############################################################################
-	SELECTIVE EXCLUSIONS
-	Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
-	#############################################################################
-	-->
-
-	<rule ref="WordPress.VIP.RestrictedFunctions">
-		<!-- This should be fine as long as the module is not used on the VIP platform.
-			 If/when it will be a wrapper can be used to use the VIP method when available
-			 and the WP native method when not.
-		-->
-		<properties>
-			<property name="exclude" value="wp_remote_get"/>
-		</properties>
-	</rule>
-
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -61,7 +61,7 @@
 		<properties>
 			<!-- Provide the prefixes to look for. -->
 			<property name="prefixes" type="array">
-				<element value="yoast"/>
+				<element value="yoast_i18n"/>
 			</property>
 		</properties>
 	</rule>

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "~0.5.0",
+        "yoast/yoastcs": "^1.0.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
     }
 }

--- a/src/i18n-v3.php
+++ b/src/i18n-v3.php
@@ -296,7 +296,7 @@ class Yoast_I18n_V3 {
 			if ( isset( $this->glotpress_logo ) && is_string( $this->glotpress_logo ) && '' !== $this->glotpress_logo ) {
 				echo '<a href="' . esc_url( $this->register_url ) . '"><img class="alignright" style="margin:0 5px 5px 5px;max-width:200px;" src="' . esc_url( $this->glotpress_logo ) . '" alt="' . esc_attr( $this->glotpress_name ) . '"/></a>';
 			}
-			// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- correctly escaped in promo_message() method.
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- correctly escaped in promo_message() method.
 			echo $message;
 			echo '</div>';
 			echo '</div>';


### PR DESCRIPTION
### Composer: require YoastCS 1.0.0

### PHPCS: update ruleset and annotations for YoastCS/WPCS 1.0.0

* The `VIP` sniffs have been deprecated in WPCS 1.0.0 and are no longer included in the YoastCS ruleset.
* The `EscapeOutput` sniff has been moved to the `Security` category in WPCS 1.0.0.

### PHPCS: make the prefix used more specific 