### PR TITLE
Build/Travis: test builds against PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ php:
 jobs:
   fast_finish: true
   include:
-    - php: 7.2
+    - php: 7.3
       env: PHPCS=1
     - php: 5.3
       dist: precise
@@ -47,7 +47,7 @@ script:
 
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate
-- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.2" ]]; then composer validate --no-check-all; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
 
 # Check the code against YoastCS.
 - if [[ $PHPCS == "1" ]]; then vendor/bin/phpcs -q; fi


### PR DESCRIPTION
Once PHP 7.3-beta came out, the `nightly` build on Travis became PHP 7.4-dev and builds haven't been tested against PHP 7.3 for months now.

As of this week, Travis has (finally) made a PHP 7.3 alias available now RC3 is out, so I've updated the highest PHP version to test against to PHP 7.3 so there won't be any unwelcome surprises when PHP 7.3 comes out.