### PR TITLE
Composer: require YoastCS 1.1.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="Yoast I18n module">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	name="Yoast I18n module"
+	xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
 	<description>Yoast I18n module rules for PHP_CodeSniffer</description>
 
 	<!--

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^1.0.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+        "yoast/yoastcs": "^1.1.0"
     }
 }


### PR DESCRIPTION
* Includes adding the PHPCS XSD to the custom ruleset which should now be valid as the minimum PHPCS requirement has gone up to PHPCS 3.3.2.
* Includes removing the DealerDirect Composer PHPCS plugin which now comes automatically with YoastCS.

No code CS changes needed.