### PR TITLE
Composer: require YoastCS ^1.2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^1.1.0"
+        "yoast/yoastcs": "^1.2.2"
     }
 }


### PR DESCRIPTION
Updates the CS requirements to YoastCS 1.2.2.

No changes to the code are needed.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/1.2.0
* https://github.com/Yoast/yoastcs/releases/tag/1.2.1
* https://github.com/Yoast/yoastcs/releases/tag/1.2.2