### PR TITLE
Composer: sync with other config files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,31 @@
         }
     ],
     "support"    : {
-        "issues": "https://github.com/Yoast/i18n-module/issues"
+        "issues": "https://github.com/Yoast/i18n-module/issues",
+        "source": "https://github.com/Yoast/i18n-module"
     },
     "autoload"   : {
         "classmap": ["src/"]
     },
+    "require": {
+        "php": ">=5.2"
+    },
     "require-dev": {
         "roave/security-advisories": "dev-master",
         "yoast/yoastcs": "^1.1.0"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "scripts": {
+        "config-yoastcs" : [
+            "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
+        ],
+        "check-cs": [
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+        ],
+        "fix-cs": [
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+        ]
     }
 }


### PR DESCRIPTION
I've done a compare between the `composer.json` config files in (nearly) all plugin repos.

This commit adds some additional properties to the config file to improve consistency with the other repos and predictability for devs.

* Adds an explicit minimum PHP version.
* Adds `config-yoastcs`, `check-cs` and `fix-cs` scripts for use by devs.
    Note: the `config-yoastcs` script is not _needed_ as the DealerDirect plugin sorts this out automatically, however for consistency of the scripts between repos, this has been added anyway.
* Add a few miscellaneous other properties.