### PR TITLE
Add extra check to handle formal and informal locales.

### DIFF
--- a/src/i18n-v3.php
+++ b/src/i18n-v3.php
@@ -384,12 +384,14 @@ class Yoast_I18n_V3 {
 					continue;
 				}
 
+				// For informal and formal locales, we have to complete the locale code by concatenating the slug ('formal' or 'informal') to the xx_XX part.
+				if ( $set->slug !== 'default' && strtolower( $this->locale ) === strtolower( $set->wp_locale . '_' . $set->slug ) ) {
+					return $set;
+				}
+
 				if ( $this->locale === $set->wp_locale ) {
 					return $set;
 				}
-			}
-			if ( $set->slug !== 'default' && strtolower( $this->locale ) === strtolower( $set->wp_locale . '_' . $set->slug ) ) {
-				return $set;
 			}
 		}
 

--- a/src/i18n-v3.php
+++ b/src/i18n-v3.php
@@ -388,6 +388,9 @@ class Yoast_I18n_V3 {
 					return $set;
 				}
 			}
+			if ( $set->slug !== 'default' && strtolower( $this->locale ) === strtolower( $set->wp_locale . '_' . $set->slug ) ) {
+				return $set;
+			}
 		}
 
 		return null;


### PR DESCRIPTION
## Changelog:
- Fixes a bug where a 'You're using WordPress in a language we don't support yet.' notice would be shown for formal and informal locales when the locale actually was supported.

## Technical choices:
The wp_locale in the translation_sets object do not contain the _formal or _informal part. For example: the wp_locale of Dutch (Formal) is nl_NL. The information that it's formal is only in the `slug` property. Because this->locale does have the _formal or _informal part, the comparison with the wp_locale had an incorrect result for informal and formal languages. This commit adds an extra check in which the slug is appended to the locale if the slug is not 'default' (i.e. is 'informal' or 'formal'). This string is compared to this->locale to make sure the correct $set is returned.

## Test instructions:
On **wordpress-seo** trunk:
- Go to settings >General and change the language to `Deutsch (Sie)`.
- Go to SEO > General. Even though German Formal is  99% translated, you'll see a 'You're using WordPress in a language we don't support yet.' notice on the dashboard.

Copy the code changes from this PR to **wordpress-seo**'s  vendor > yoast > i18n-module > src > i18n-module.php.
- [> 90% translated formal language] (Keep the language set to `Deutsch (Sie)`) Go to SEO > General. See no translation-related notice.
- [> 90% translated non-formal language] Set the language to English (US). See no translation-related notice.
- [partly translated formal language] Set the language to Dutch (Formal). You'll see "Zoals u kunt zien is er een vertaling van deze plugin in Dutch (Formal). Deze vertaling is momenteel voor 57% klaar... ".
- [partly translated informal language] Set the language to Deutsch (Schweiz, Du). You'll see "Wie du sehen kannst, existiert eine Übersetzung dieses Plugins in German (Switzerland) Informal. Diese Übersetzung ist aktuell zu 61% fertiggestellt. "
- [partly translated non-formal language] "You're using WordPress in Esperanto. While Yoast SEO has been translated to Esperanto for 8%, it's not been shipped with the plugin yet."
