### PR TITLE
Revert "CS: fix capitalization in class names"

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -38,6 +38,7 @@
 	<rule ref="Yoast">
 		<!-- Can't be helped, textdomain is passed in dynamically, that's the nature of this module. -->
 		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralDomain"/>
+		<exclude name="PEAR.NamingConventions.ValidClassName.Invalid"/>
 	</rule>
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.1.1
+
+### Fixed
+- Reverts the capitalization of the class names.
+
 ## 3.1.0
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Alternatively you can include the library as a submodule.
 Make sure the class is loaded and instantiate it like this:
 
 ```php
-new Yoast_I18n_V3(
+new Yoast_I18n_v3(
 	array(
 		'textdomain'     => '{your text domain}',
 		'project_slug'   => '{your probject slug}',
@@ -39,7 +39,7 @@ new Yoast_I18n_V3(
 Because translate.wordpress.org is also a GlotPress installation you can use the i18n-module to promote translation your plugin on there. To do this you can use the dedicated wordpress.org class:
 
 ```php
-new Yoast_I18n_WordPressOrg_V3(
+new Yoast_I18n_WordPressOrg_v3(
 	array(
 		'textdomain'  => '{your text domain}',
 		'plugin_name' => '{your plugin name}',
@@ -53,7 +53,7 @@ new Yoast_I18n_WordPressOrg_V3(
 Since 3.0.0 you can also decide to render the message in a message-box of your own, just provide the second argument to the constructor as `false` to disable the showing of the box by the module itself.
 
 ```php
-$i18n_module = new Yoast_I18n_V3(
+$i18n_module = new Yoast_I18n_v3(
 	array(
 		'textdomain'     => '{your text domain}',
 		'project_slug'   => '{your probject slug}',
@@ -71,7 +71,7 @@ $message = $i18n_module->get_promo_message();
 ```
 
 ```php
-$i18n_module = new Yoast_I18n_WordPressOrg_V3(
+$i18n_module = new Yoast_I18n_WordPressOrg_v3(
 	array(
 		'textdomain'  => '{your text domain}',
 		'plugin_name' => '{your plugin name}',

--- a/src/i18n-v3.php
+++ b/src/i18n-v3.php
@@ -9,7 +9,7 @@
  * This class defines a promo box and checks your translation site's API for stats about it,
  * then shows them to the user.
  */
-class Yoast_I18n_V3 {
+class Yoast_I18n_v3 {
 
 	/**
 	 * Your translation site's logo.

--- a/src/i18n-wordpressorg-v3.php
+++ b/src/i18n-wordpressorg-v3.php
@@ -8,12 +8,12 @@
 /**
  * The Yoast i18n module with a connection to WordPress.org.
  */
-class Yoast_I18n_WordPressOrg_V3 {
+class Yoast_I18n_WordPressOrg_v3 {
 
 	/**
 	 * The i18n object that presents the user with the notification.
 	 *
-	 * @var yoast_i18n_V3
+	 * @var yoast_i18n_v3
 	 */
 	protected $i18n;
 
@@ -28,7 +28,7 @@ class Yoast_I18n_WordPressOrg_V3 {
 	public function __construct( $args, $show_translation_box = true ) {
 		$args = $this->set_defaults( $args );
 
-		$this->i18n = new Yoast_I18n_V3( $args, $show_translation_box );
+		$this->i18n = new Yoast_I18n_v3( $args, $show_translation_box );
 		$this->set_api_url( $args['textdomain'] );
 	}
 


### PR DESCRIPTION
This reverts commit 87aef6aa623a5076293064ebcd85de720d6e5fe5. 

Because capitalization matters when loading dependencies with composer like we do in our plugins, this is in a way a breaking change. That's why I'm reverting it for now.