### PR TITLE
Stop explicit support for PHP < 5.6 /  WP < 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 dist: trusty
-sudo: false
 
 cache:
   directories:
@@ -20,20 +19,17 @@ php:
   - 7.0
   - 5.6
   - "7.4snapshot"
+  - "nightly"
 
 jobs:
   fast_finish: true
   include:
     - php: 7.3
       env: PHPCS=1
-    - php: 5.3
-      dist: precise
-    - php: 5.2
-      dist: precise
 
   allow_failures:
     # Allow failures for unstable builds.
-    - php: "7.4snapshot"
+    - php: "nightly"
 
 before_install:
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
@@ -47,7 +43,7 @@ script:
 
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate
-- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
 
 # Check the code against YoastCS.
 - if [[ $PHPCS == "1" ]]; then vendor/bin/phpcs -q; fi

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "classmap": ["src/"]
     },
     "require": {
-        "php": ">=5.2"
+        "php": ">=5.6"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",


### PR DESCRIPTION
Includes:
* Removing builds against PHP < 5.6.
* Removing the build against PHP 7.4 from allowed failures.
* Adding back a build against PHP `nightly` (PHP 8).

As the I18n module does not contain unit tests, these changes can already be made and made in one go.

Also:
* Travis hasn't supported `sudo` for quite a while now, so removing it.