### PR TITLE
PHPCS: Update to YoastCS 2.0.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -34,6 +34,14 @@
 	-->
 
 	<rule ref="Yoast">
+		<!-- Provide the plugin specific prefixes for all naming related sniffs. -->
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="Yoast\WP\I18n"/>
+				<element value="yoast_i18n"/>
+			</property>
+		</properties>
+
 		<!-- Can't be helped, textdomain is passed in dynamically, that's the nature of this module. -->
 		<exclude name="WordPress.WP.I18n.NonSingularStringLiteralDomain"/>
 
@@ -42,6 +50,7 @@
 			 plugins which include this module, unless the classname is also adjusted in the
 			 plugin.
 			 See:
+			 - https://github.com/Yoast/i18n-module/issues/51
 			 - https://github.com/Yoast/i18n-module/pull/29
 			 - https://github.com/Yoast/i18n-module/pull/49 -->
 		<exclude name="PEAR.NamingConventions.ValidClassName.Invalid"/>
@@ -57,19 +66,17 @@
 	<rule ref="Yoast.Files.FileName">
 		<properties>
 			<!-- Remove the following prefixes from the names of object structures. -->
-			<property name="prefixes" type="array">
+			<property name="oo_prefixes" type="array">
 				<element value="yoast"/>
 			</property>
 		</properties>
 	</rule>
 
-	<!-- Verify that everything in the global namespace is prefixed with a plugin specific prefix. -->
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+	<rule ref="Yoast.NamingConventions.NamespaceName">
 		<properties>
-			<!-- Provide the prefixes to look for. -->
-			<property name="prefixes" type="array">
-				<element value="yoast_i18n"/>
-				<element value="Yoast\WP\I18n"/>
+			<!-- Treat the "src" directory as the project root for path to namespace translations. -->
+			<property name="src_directory" type="array">
+				<element value="src"/>
 			</property>
 		</properties>
 	</rule>

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^1.3.0"
+        "yoast/yoastcs": "^2.0.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/i18n-v3.php
+++ b/src/i18n-v3.php
@@ -146,7 +146,7 @@ class Yoast_I18n_v3 {
 	 * @return bool Returns true if the language is en_US.
 	 */
 	protected function is_default_language( $language ) {
-		return 'en_US' === $language;
+		return $language === 'en_US';
 	}
 
 	/**
@@ -293,7 +293,7 @@ class Yoast_I18n_v3 {
 			echo '<div>';
 			/* translators: %s: plugin name. */
 			echo '<h2>' . sprintf( esc_html__( 'Translation of %s', $this->textdomain ), esc_html( $this->plugin_name ) ) . '</h2>';
-			if ( isset( $this->glotpress_logo ) && is_string( $this->glotpress_logo ) && '' !== $this->glotpress_logo ) {
+			if ( isset( $this->glotpress_logo ) && is_string( $this->glotpress_logo ) && $this->glotpress_logo !== '' ) {
 				echo '<a href="' . esc_url( $this->register_url ) . '"><img class="alignright" style="margin:0 5px 5px 5px;max-width:200px;" src="' . esc_url( $this->glotpress_logo ) . '" alt="' . esc_attr( $this->glotpress_name ) . '"/></a>';
 			}
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- correctly escaped in promo_message() method.

--- a/src/i18n-v3.php
+++ b/src/i18n-v3.php
@@ -134,7 +134,7 @@ class Yoast_I18n_v3 {
 		$this->init( $args );
 
 		if ( $show_translation_box ) {
-			add_action( $this->hook, array( $this, 'promo' ) );
+			add_action( $this->hook, [ $this, 'promo' ] );
 		}
 	}
 
@@ -273,7 +273,7 @@ class Yoast_I18n_v3 {
 		return sprintf(
 			/* translators: %1$s is the notification dismissal link start tag, %2$s is the link closing tag. */
 			esc_html__( '%1$sPlease don\'t show me this notification anymore%2$s', $this->textdomain ),
-			'<a class="button" href="' . esc_url( add_query_arg( array( 'remove_i18n_promo' => '1' ) ) ) . '">',
+			'<a class="button" href="' . esc_url( add_query_arg( [ 'remove_i18n_promo' => '1' ] ) ) . '">',
 			'</a>'
 		);
 	}
@@ -288,7 +288,7 @@ class Yoast_I18n_v3 {
 
 		if ( $message ) {
 			echo '<div id="i18n_promo_box" style="border:1px solid #ccc;background-color:#fff;padding:10px;max-width:650px; overflow: hidden;">';
-			echo '<a href="' . esc_url( add_query_arg( array( 'remove_i18n_promo' => '1' ) ) ) . '" style="color:#333;text-decoration:none;font-weight:bold;font-size:16px;border:1px solid #ccc;padding:1px 4px;" class="alignright">X</a>';
+			echo '<a href="' . esc_url( add_query_arg( [ 'remove_i18n_promo' => '1' ] ) ) . '" style="color:#333;text-decoration:none;font-weight:bold;font-size:16px;border:1px solid #ccc;padding:1px 4px;" class="alignright">X</a>';
 
 			echo '<div>';
 			/* translators: %s: plugin name. */


### PR DESCRIPTION
### PHPCS: Update to YoastCS 2.0.0

This updates the dependency in `composer.json`, as well as the PHPCS ruleset for YoastCS 2.0.0.

Ref: https://github.com/Yoast/yoastcs/releases/tag/2.0.0

### CS: use short arrays

### CS: don't use Yoda conditions 