### PR TITLE
Travis: use 7.4 not snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,12 @@ branches:
 php:
   - 7.0
   - 5.6
-  - "7.4snapshot"
   - "nightly"
 
 jobs:
   fast_finish: true
   include:
-    - php: 7.3
+    - php: 7.4
       env: PHPCS=1
 
   allow_failures:
@@ -43,7 +42,7 @@ script:
 
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate
-- if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.4" ]]; then composer validate --no-check-all; fi
 
 # Check the code against YoastCS.
 - if [[ $PHPCS == "1" ]]; then vendor/bin/phpcs -q; fi


### PR DESCRIPTION
Since mid December, Travis now has a native PHP 7.4 image available.