### PR TITLE
Composer: update to YoastCS 2.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,7 @@
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^2.1.0",
-        "php-parallel-lint/php-parallel-lint": "^1.3",
-        "php-parallel-lint/php-console-highlighter": "^0.5"
+        "yoast/yoastcs": "^2.2.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
... which includes PHP Parallel Lint by design, so no need to require it separately anymore.

Ref: https://github.com/Yoast/yoastcs/releases