### PR TITLE
Travis: add build against PHP 8.0/remove nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,15 @@ branches:
     - /^hotfix\/\d+\.\d+(\.\d+)?(-\S*)?$/
 
 php:
+  - 8.0
   - 7.0
   - 5.6
-  - "nightly"
 
 jobs:
   fast_finish: true
   include:
     - php: 7.4
       env: PHPCS=1
-
-  allow_failures:
-    # Allow failures for unstable builds.
-    - php: "nightly"
 
 before_install:
   - phpenv config-rm xdebug.ini || echo 'No xdebug config.'


### PR DESCRIPTION
At this time, the current PHP 8.0 version is `8.0.11`. The Travis PHP `8.0` image yields PHP `8.0.9`, which is good enough for PHP 8.0.

`nightly` however is PHP `8.0.3` and hasn't been updated since Feb 2021, so running tests against that image is completely useless at this time.

Notes:
* Tested `nightly` against all relevant `dist`s - `xenial`, `bionic` and `focal` and none have a more current image.
* The [PHP Build project](https://github.com/php-build/php-build/tree/master/share/php-build/definitions), which Travis pulls its images from, _does_ have a PHP `8.1snapshot` image available.
    I've tested to see if that image is available on Travis, but unfortunately, no luck there either.